### PR TITLE
add extra args to pass to process run

### DIFF
--- a/ecosystem/main.py
+++ b/ecosystem/main.py
@@ -90,6 +90,7 @@ def resolve_presets(presets):
 
 def call_process(arguments):
     if _ON_WINDOWS:
+        print('ecosystem run command line : {arguments}'.format(**locals()))
         subprocess.call(arguments, shell=True)
     else:
         subprocess.call(arguments)
@@ -118,12 +119,14 @@ def build(tools=None, force_rebuild=False, quick_build=False, deploy=False):
         call_process(MAKE_COMMAND)
 
 
-def run(tools=None, run_application=None):
+def run(tools=None, run_application=None, extra_args=None):
     tools = tools or []
+    extra_args = extra_args or []
     env = Environment(tools)
+    cmd = [run_application] + extra_args
     if env.success:
         env.set_env(os.environ)
-        call_process([run_application])
+        call_process(cmd)
 
 
 def set_environment(tools=None):
@@ -166,10 +169,14 @@ Example:
                         help='output setenv statements to be used to set the shells environment')
     parser.add_argument('-p', '--presets', type=str, default=None,
                         help='specify a list of presets if any')
+    parser.add_argument('-x', '--extra', type=str, default=None,
+                        help='specify a list of extra args pass to run application, separated by commas')
 
     args = parser.parse_args(argv)
 
     tools = args.tools.split(',') if args.tools is not None else []
+
+    extra = args.extra.split(',') if args.extra is not None else []
 
     # assuming tools defined take precedence over any in a preset
     if args.presets:
@@ -186,7 +193,7 @@ Example:
             else:
                 build(tools, args.force, args.make, args.deploy)
         elif args.run is not None:
-            run(tools, args.run)
+            run(tools, args.run, extra)
         elif args.setenv:
             set_environment(tools)
         return 0


### PR DESCRIPTION
Very useful  features to pass args to application : 
`python main.py -t maya2017 -r maya -x my_file.ma`
if it already exists I'm missing something. 
Anyway thank for this tool. 